### PR TITLE
Add hal::esp8266::at::wlan_client

### DIFF
--- a/include/libesp8266/http.hpp
+++ b/include/libesp8266/http.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <span>
+#include <string_view>
+
+#include <libhal/units.hpp>
+
+namespace hal::esp8266 {
+
+enum class http_method
+{
+  /// The GET method requests a representation of the specified resource.
+  /// Requests using GET should only retrieve data.
+  GET,
+  /// The HEAD method asks for a response identical to a GET request, but
+  /// without the response body.
+  HEAD,
+  /// The POST method submits an entity to the specified resource, often
+  /// causing a change in state or side effects on the server.
+  POST,
+  /// The PUT method replaces all current representations of the target
+  /// resource with the request payload.
+  PUT,
+  /// The DELETE method deletes the specified resource.
+  DELETE,
+  /// The CONNECT method establishes a tunnel to the server identified by the
+  /// target resource.
+  CONNECT,
+  /// The OPTIONS method describes the communication options for the target
+  /// resource.
+  OPTIONS,
+  /// The TRACE method performs a message loop-back test along the path to the
+  /// target resource.
+  TRACE,
+  /// The PATCH method applies partial modifications to a resource.
+  PATCH,
+};
+
+struct request_t
+{
+  /**
+   * @brief Domain name of the server to connect to. This should not include
+   * stuff like "http://" or "www". An example would be `google.com`,
+   * `example.com`, or `developer.mozilla.org`.
+   *
+   */
+  std::string_view domain;
+  /**
+   * @brief path to the resource within the domain url. To get the root page,
+   * use "/" (or "/index.html"). URL parameters can also be placed in the path
+   * as well such as "/search?query=wifi_client&price=lowest"
+   *
+   */
+  std::string_view path = "/";
+  /**
+   * @brief which http method to use for this request. Most web servers use
+   * GET and POST and tend to ignore the others.
+   *
+   */
+  http_method method = http_method::GET;
+  /**
+   * @brief Data to transmit to web server. This field is typically used (or
+   * non-null) when performing POST requests. Typically this field will be
+   * ignored if the method choosen is HEAD or GET. Set this to an empty span
+   * if there is no data to be sent.
+   *
+   */
+  std::span<const hal::byte> send_data = {};
+  /**
+   * @brief which server port number to connect to.
+   *
+   */
+  std::string_view port = "80";
+};
+
+struct header_t
+{
+  uint32_t status_code = 0;
+  size_t content_length = 0;
+  size_t header_length = 0;
+
+  bool is_valid()
+  {
+    return status_code != 0 && content_length != 0 && header_length != 0;
+  }
+};
+
+inline std::string_view to_string(http_method p_method)
+{
+  switch (p_method) {
+    case http_method::GET:
+      return "GET";
+    case http_method::HEAD:
+      return "HEAD";
+    case http_method::POST:
+      return "POST";
+    case http_method::PUT:
+      return "PUT";
+    case http_method::DELETE:
+      return "DELETE";
+    case http_method::CONNECT:
+      return "CONNECT";
+    case http_method::OPTIONS:
+      return "OPTIONS";
+    case http_method::TRACE:
+      return "TRACE";
+    case http_method::PATCH:
+      return "PATCH";
+  }
+}
+} // namespace hal::esp8266

--- a/include/libesp8266/wifi.hpp
+++ b/include/libesp8266/wifi.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace hal::esp8266 {
+/// The type of password security used for the access point.
+enum class access_point_security
+{
+  open,
+  wep,
+  wpa_psk,
+  wpa2_psk,
+  wpa_wpa2_psk,
+};
+} // namespace hal::esp8266

--- a/include/libesp8266/wlan_client.hpp
+++ b/include/libesp8266/wlan_client.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <libhal/serial/coroutines.hpp>
+#include <libhal/serial/interface.hpp>
+#include <libhal/serial/util.hpp>
+#include <string_view>
+
+#include "http.hpp"
+#include "wifi.hpp"
+
+namespace hal::esp8266::at {
+/**
+ * @brief wlan_client AT command driver for connecting to WiFi Access points
+ *
+ */
+class wlan_client
+{
+public:
+  /// Default baud rate for the wlan_client AT commands
+  static constexpr uint32_t default_baud_rate = 115200;
+  /// Confirmation response
+  static constexpr std::string_view ok_response = "OK\r\n";
+  /// Confirmation response after a wifi successfully connected
+  static constexpr std::string_view wifi_connected =
+    "WIFI GOT IP\r\n\r\nOK\r\n";
+  /// Confirmation response after a reset completes
+  static constexpr std::string_view reset_complete = "ready\r\n";
+  /// End of header
+  static constexpr std::string_view end_of_header = "\r\n\r\n";
+  /// The maximum packet size for wlan_client AT commands
+  static constexpr size_t maximum_response_packet_size = 1460;
+  static constexpr size_t maximum_transmit_packet_size = 2048;
+
+  static result<wlan_client> create(hal::serial& p_serial,
+                                    std::string_view p_ssid,
+                                    std::string_view p_password,
+                                    timeout auto p_timeout)
+  {
+    HAL_CHECK(p_serial.configure({
+      .baud_rate = 115200,
+      .stop = hal::serial::settings::stop_bits::one,
+      .parity = hal::serial::settings::parity::none,
+    }));
+
+    HAL_CHECK(p_serial.flush());
+
+    wlan_client client(p_serial);
+    HAL_CHECK(client.connect(p_ssid, p_password, p_timeout));
+
+    return client;
+  }
+
+  /**
+   * @brief checks the connection state to an access point.
+   *
+   * @return true is connected to access point
+   * @return false is NOT connected access point
+   */
+  bool connected() { return m_connected; }
+
+  status connect(std::string_view p_ssid,
+                 std::string_view p_password,
+                 timeout auto p_timeout)
+  {
+    // Reset the device
+    HAL_CHECK(write("AT+RST\r\n"));
+    auto skipper = hal::skip_past(*m_serial, as_bytes(reset_complete));
+    /* HAL_CHECK(try_until(skipper, p_timeout)); */
+
+    // Turn off echo
+    HAL_CHECK(write("ATE0\r\n"));
+    skipper = hal::skip_past(*m_serial, as_bytes(ok_response));
+    /* HAL_CHECK(try_until(skipper, p_timeout)); */
+
+    // Configure as WiFi Station (client) mode
+    HAL_CHECK(write("AT+CWMODE=1\r\n"));
+    skipper = hal::skip_past(*m_serial, as_bytes(ok_response));
+    /* HAL_CHECK(try_until(skipper, p_timeout)); */
+
+    // Connect to wifi access point
+    HAL_CHECK(write("AT+CWJAP_CUR=\""));
+    HAL_CHECK(write(m_ssid));
+    HAL_CHECK(write("\",\""));
+    HAL_CHECK(write(m_password));
+    HAL_CHECK(write("\"\r\n"));
+    skipper = hal::skip_past(*m_serial, as_bytes(ok_response));
+    /* HAL_CHECK(try_until(skipper, p_timeout)); */
+
+    return hal::success();
+  }
+
+  /**
+   * @brief After issuing a request, this function must be called in order to
+   * progress the http request. This function manages, connecting to the server,
+   * sending the request to server and receiving data from the server.
+   *
+   * @return state is the state of the current transaction. This value
+   * can be checked to determine if a certain stage is taking too long.
+   */
+  result<work_state> operator()();
+
+private:
+  /**
+   * @param p_serial the serial port connected to the wlan_client
+   * @param p_baud_rate the operating baud rate for the wlan_client
+   *
+   */
+  wlan_client(hal::serial& p_serial)
+    : m_serial{ &p_serial }
+  {}
+
+  result<void> write(std::string_view p_string)
+  {
+    return hal::write(*m_serial, p_string);
+  }
+
+  serial* m_serial;
+  bool m_connected = false;
+};
+} // namespace hal::esp8266::at


### PR DESCRIPTION
wlan_client is an object that connects an esp8266 to a wireless access point.

Future plan is to pass this object to an `http_request` function which returns a resumable callable object that process an http_request.