### PR TITLE
Update to libhal 0.1.33

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class Libesp8266Conan(ConanFile):
     name = "libesp8266"
-    version = "0.0.5"
+    version = "0.0.6"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libhal/libesp8266"

--- a/demos/applications/http_get.cpp
+++ b/demos/applications/http_get.cpp
@@ -61,13 +61,14 @@ hal::status application(hal::esp8266::hardware_map& p_map)
   while (true) {
     buffer.fill('.');
 
+    auto time_limit = HAL_CHECK(hal::create_timeout(counter, 5000ms));
+
     // Create http get request to example.com/ on port 80
     auto get_request = HAL_CHECK(hal::esp8266::http::get::create(
-      socket, buffer, "/", "example.com", "80"));
+      socket, buffer, time_limit, "/", "example.com", "80"));
 
     // Wait until GET request response is finished
-    auto state = HAL_CHECK(hal::try_until(
-      get_request, HAL_CHECK(hal::create_timeout(counter, 5000ms))));
+    auto state = HAL_CHECK(hal::try_until(get_request, time_limit));
 
     // If the state came back as finished, print the response to the user
     if (state == hal::work_state::finished) {

--- a/demos/applications/wlan_client.cpp
+++ b/demos/applications/wlan_client.cpp
@@ -61,7 +61,8 @@ hal::status application(hal::esp8266::hardware_map& p_map)
     HAL_CHECK(hal::write(debug, "Sending:\n\n"));
     HAL_CHECK(hal::write(debug, get_request));
     HAL_CHECK(hal::write(debug, "\n\n"));
-    HAL_CHECK(tcp_socket.write(hal::as_bytes(get_request)));
+    HAL_CHECK(tcp_socket.write(hal::as_bytes(get_request),
+                               HAL_CHECK(hal::create_timeout(counter, 500ms))));
 
     // Wait 1 second before reading response back
     HAL_CHECK(hal::delay(counter, 1000ms));

--- a/include/libesp8266/http_response.hpp
+++ b/include/libesp8266/http_response.hpp
@@ -26,6 +26,7 @@ public:
 
   static result<get> create(hal::socket& p_socket,
                             std::span<hal::byte> p_buffer,
+                            timeout auto p_timeout,
                             std::string_view p_path,
                             std::string_view p_domain,
                             std::string_view p_port = "",
@@ -34,28 +35,30 @@ public:
     using namespace std::literals;
 
     // Send GET request header line
-    HAL_CHECK(p_socket.write(as_bytes("GET "sv)));
-    HAL_CHECK(p_socket.write(as_bytes(p_path)));
-    HAL_CHECK(p_socket.write(as_bytes(" HTTP/1.1\r\n"sv)));
+    HAL_CHECK(p_socket.write(as_bytes("GET "sv), p_timeout));
+    HAL_CHECK(p_socket.write(as_bytes(p_path), p_timeout));
+    HAL_CHECK(p_socket.write(as_bytes(" HTTP/1.1\r\n"sv), p_timeout));
     // Send HOST line
-    HAL_CHECK(p_socket.write(as_bytes("Host: "sv)));
-    HAL_CHECK(p_socket.write(as_bytes(p_domain)));
+    HAL_CHECK(p_socket.write(as_bytes("Host: "sv), p_timeout));
+    HAL_CHECK(p_socket.write(as_bytes(p_domain), p_timeout));
     if (!p_port.empty()) {
-      HAL_CHECK(p_socket.write(as_bytes(":"sv)));
-      HAL_CHECK(p_socket.write(as_bytes(p_port)));
+      HAL_CHECK(p_socket.write(as_bytes(":"sv), p_timeout));
+      HAL_CHECK(p_socket.write(as_bytes(p_port), p_timeout));
     }
-    HAL_CHECK(p_socket.write(as_bytes("\r\n"sv)));
+    HAL_CHECK(p_socket.write(as_bytes("\r\n"sv), p_timeout));
     // Send keep alive line
     switch (p_keep_alive) {
       case connection::keep_alive:
-        HAL_CHECK(p_socket.write(as_bytes("Connection: keep-alive\r\n"sv)));
+        HAL_CHECK(
+          p_socket.write(as_bytes("Connection: keep-alive\r\n"sv), p_timeout));
         break;
       case connection::close:
-        HAL_CHECK(p_socket.write(as_bytes("Connection: close\r\n"sv)));
+        HAL_CHECK(
+          p_socket.write(as_bytes("Connection: close\r\n"sv), p_timeout));
         break;
     }
     // Send final newline
-    HAL_CHECK(p_socket.write(as_bytes("\r\n"sv)));
+    HAL_CHECK(p_socket.write(as_bytes("\r\n"sv), p_timeout));
 
     return get(p_socket, p_buffer);
   }

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -26,7 +26,8 @@ int main()
                                               "example.com",
                                               "80")
                .value();
-  tcp.write(hal::as_bytes("Hello, World\r\n\r\n"sv)).value();
+  tcp.write(hal::as_bytes("Hello, World\r\n\r\n"sv), hal::never_timeout())
+    .value();
   mock.m_stream_out =
     hal::esp8266::stream_out("+IPD,15:Goodbye, World!+IPD,8:Packet 2"sv);
   std::array<hal::byte, 1024> buffer;

--- a/tests/at/socket.test.cpp
+++ b/tests/at/socket.test.cpp
@@ -42,7 +42,7 @@ boost::ut::suite socket_test = []() {
                               "example.com",
                               "80")
                  .value();
-    tcp.write(hal::as_bytes("Hello, World\r\n\r\n"sv)).value();
+    tcp.write(hal::as_bytes("Hello, World\r\n\r\n"sv), never_timeout()).value();
     mock.m_stream_out = stream_out("+IPD,15:Goodbye, World!+IPD,8:Packet 2"sv);
     std::array<hal::byte, 1024> buffer;
     buffer.fill('.');
@@ -72,7 +72,7 @@ boost::ut::suite socket_test = []() {
                               "example.com",
                               "80")
                  .value();
-    tcp.write(hal::as_bytes("Hello, World\r\n\r\n"sv)).value();
+    tcp.write(hal::as_bytes("Hello, World\r\n\r\n"sv), never_timeout()).value();
     mock.m_stream_out = stream_out("+IPD,15:Goodbye,"sv);
 
     // Exercise
@@ -114,7 +114,7 @@ boost::ut::suite socket_test = []() {
                               "example.com",
                               "80")
                  .value();
-    tcp.write(hal::as_bytes("Hello, World\r\n\r\n"sv)).value();
+    tcp.write(hal::as_bytes("Hello, World\r\n\r\n"sv), never_timeout()).value();
     mock.m_stream_out = stream_out("+IPD,15:Goodbye, World!+IPD,8:Packet 2"sv);
 
     // Exercise

--- a/tests/http_response.test.cpp
+++ b/tests/http_response.test.cpp
@@ -15,7 +15,8 @@ boost::ut::suite http_response_test = []() {
 
   private:
     hal::result<write_t> driver_write(
-      std::span<const hal::byte> p_data) noexcept
+      std::span<const hal::byte> p_data,
+      [[maybe_unused]] std::function<hal::timeout_function> p_timeout) noexcept
     {
       printf("%.*s", static_cast<int>(p_data.size()), p_data.data());
       return write_t{ p_data };
@@ -52,7 +53,9 @@ boost::ut::suite http_response_test = []() {
     fake_socket test_socket;
     test_socket.m_stream_out = stream_out(example_response);
     [[maybe_unused]] auto get_request =
-      get::create(test_socket, test_buffer, "/", "example.com", "80").value();
+      get::create(
+        test_socket, test_buffer, never_timeout(), "/", "example.com", "80")
+        .value();
 
     std::array<work_state, 80> work_states{};
 


### PR DESCRIPTION
- Bump version to 0.0.6
- http_response get() now takes a timeout object to accomidate write operations.