### PR TITLE
:rocket: Launch version 1.0.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibhalEsp8266Conan(ConanFile):
     name = "libhal-esp8266"
-    version = "0.3.5"
+    version = "1.0.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libhal/libhal-esp8266"
@@ -37,8 +37,8 @@ class LibhalEsp8266Conan(ConanFile):
         }
 
     def requirements(self):
-        self.requires("libhal/0.3.5")
-        self.requires("libhal-util/0.3.8")
+        self.requires("libhal/[^1.0.0]")
+        self.requires("libhal-util/[^1.0.0]")
 
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(demos VERSION 0.0.1 LANGUAGES CXX)
-
-find_package(libhal-lpc40xx REQUIRED CONFIG)
-find_package(libhal-esp8266 REQUIRED CONFIG)
-
 if(NOT DEFINED CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug" CACHE INTERNAL "Default to Debug Build")
 endif(NOT DEFINED CMAKE_BUILD_TYPE)
 
 set(CMAKE_TOOLCHAIN_FILE conan_toolchain.cmake)
+
+project(demos VERSION 0.0.1 LANGUAGES CXX)
+
+find_package(libhal-lpc40xx REQUIRED CONFIG)
+find_package(libhal-esp8266 REQUIRED CONFIG)
 
 set(DEMOS wlan_client http_get)
 set(TARGETS lpc4078 lpc4074)

--- a/demos/applications/helper.hpp
+++ b/demos/applications/helper.hpp
@@ -48,7 +48,7 @@ public:
     return result;
   }
 
-  hal::status driver_flush() override
+  hal::result<hal::serial::flush_t> driver_flush() override
   {
     return m_primary->flush();
   }

--- a/demos/conanfile.txt
+++ b/demos/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
-libhal-lpc40xx/[^0.3.11]
-libhal-esp8266/0.3.5
+libhal-lpc40xx/[^1.0.0]
+libhal-esp8266/1.0.0
 
 [tool_requires]
 gnu-arm-embedded-toolchain/11.3.0

--- a/test_package/util.test.hpp
+++ b/test_package/util.test.hpp
@@ -68,9 +68,9 @@ struct mock_serial : public hal::serial
     return m_stream_out(p_data);
   }
 
-  hal::status driver_flush() override
+  result<flush_t> driver_flush() override
   {
-    return hal::success();
+    return flush_t{};
   }
 
   size_t rotation = 0;

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 boost-ext-ut/1.1.9
-libhal-esp8266/0.3.5
+libhal-esp8266/1.0.0
 
 [generators]
 CMakeToolchain

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -68,9 +68,9 @@ struct mock_serial : public hal::serial
     return m_stream_out(p_data);
   }
 
-  hal::status driver_flush() override
+  result<flush_t> driver_flush() override
   {
-    return hal::success();
+    return flush_t{};
   }
 
   size_t rotation = 0;


### PR DESCRIPTION
- :arrow_up: Upgrade to libhal/[^1.0.0].
- :arrow_up: Upgrade to libhal-util/[^1.0.0].
- :arrow_up: Upgrade to libhal-lpc40xx/[^1.0.0] for demos.
- :recycle: Refactor code to use latest libhal code
- :adhesive_bandage: Fix ordering of toolchain code in demos/CMakeLists.txt