### PR TITLE
:bug: Fix http::create() flakiness

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibhalEsp8266Conan(ConanFile):
     name = "libhal-esp8266"
-    version = "1.0.0"
+    version = "1.0.1"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libhal/libhal-esp8266"
@@ -55,18 +55,36 @@ class LibhalEsp8266Conan(ConanFile):
     def requirements(self):
         self.requires("libhal/[^1.0.0]")
         self.requires("libhal-util/[^1.0.0]")
+        self.requires("etl/20.35.11")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def layout(self):
         cmake_layout(self)
 
+    def build(self):
+        if not self.conf.get("tools.build:skip_test", default=False):
+            cmake = CMake(self)
+            if self.settings.os == "Windows":
+                cmake.configure(build_script_folder="tests")
+            else:
+                cmake.configure(build_script_folder="tests",
+                                variables={"ENABLE_ASAN": True})
+            cmake.build()
+            self.run(os.path.join(self.cpp.build.bindir, "unit_test"))
+
     def package(self):
-        copy(self, "LICENSE", dst=os.path.join(
-            self.package_folder, "licenses"), src=self.source_folder)
-        copy(self, "*.h", dst=os.path.join(self.package_folder, "include"),
+        copy(self,
+             "LICENSE",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        copy(self,
+             "*.h",
+             dst=os.path.join(self.package_folder, "include"),
              src=os.path.join(self.source_folder, "include"))
-        copy(self, "*.hpp", dst=os.path.join(self.package_folder,
-             "include"), src=os.path.join(self.source_folder, "include"))
+        copy(self,
+             "*.hpp",
+             dst=os.path.join(self.package_folder, "include"),
+             src=os.path.join(self.source_folder, "include"))
 
     def package_info(self):
         self.cpp_info.bindirs = []
@@ -74,5 +92,6 @@ class LibhalEsp8266Conan(ConanFile):
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = []
         self.cpp_info.set_property("cmake_target_name", "libhal::esp8266")
+
     def package_id(self):
         self.info.clear()

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -8,7 +8,7 @@ class RmdDemos(ConanFile):
 
     def requirements(self):
         self.requires("libhal-lpc40xx/[^1.0.0]")
-        self.requires("libhal-esp8266/1.0.0")
+        self.requires("libhal-esp8266/1.0.1")
         self.tool_requires("gnu-arm-embedded-toolchain/11.3.0")
         self.tool_requires("cmake-arm-embedded/0.1.1")
 

--- a/include/libhal-esp8266/at/socket.hpp
+++ b/include/libhal-esp8266/at/socket.hpp
@@ -161,6 +161,7 @@ private:
     hal::function_ref<hal::timeout_function> p_timeout) override
   {
     using namespace std::literals;
+
     if (p_data.size() > maximum_transmit_packet_size) {
       return new_error(std::errc::file_too_large);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,9 @@ else()
 endif()
 
 find_package(ut REQUIRED CONFIG)
-find_package(libhal-esp8266 REQUIRED CONFIG)
+find_package(libhal REQUIRED CONFIG)
+find_package(libhal-util REQUIRED CONFIG)
+find_package(etl REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME}
   at/wlan_client.test.cpp
@@ -54,7 +56,11 @@ target_link_options(${PROJECT_NAME} PRIVATE
   -fprofile-arcs
   -ftest-coverage
   ${ASAN_FLAG})
-target_link_libraries(${PROJECT_NAME} PRIVATE boost-ext-ut::ut libhal::libhal libhal::util)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  boost-ext-ut::ut
+  libhal::libhal
+  libhal::util
+  etl)
 
 add_custom_command(TARGET ${PROJECT_NAME}
   POST_BUILD


### PR DESCRIPTION
Previous implementation used multiple socket::write() commands to transmit the header piece by piece. This approach, although it saves stack space, will cause most HTTP web servers to timeout. The header needs to be sent in a single packet and thus the http::create API now takes a template parameter that defines the size of header buffer.

- :arrow_up: Bump version to 1.0.1

Resolves #36 