### PR TITLE
:green_heart: Fix ETL & lpc40 dependency

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ import os
 required_conan_version = ">=1.50.0"
 
 
-class LibhalEsp8266Conan(ConanFile):
+class libhal_esp8266_conan(ConanFile):
     name = "libhal-esp8266"
     version = "1.0.2"
     license = "Apache-2.0"
@@ -34,6 +34,7 @@ class LibhalEsp8266Conan(ConanFile):
     settings = "compiler", "build_type", "os", "arch"
     exports_sources = "include/*", "tests/*", "LICENSE"
     generators = "CMakeToolchain", "CMakeDeps"
+    package_type = "header-library"
     no_copy_source = True
 
     @property
@@ -69,7 +70,7 @@ class LibhalEsp8266Conan(ConanFile):
     def requirements(self):
         self.requires("libhal/[^1.0.0]")
         self.requires("libhal-util/[^1.0.0]")
-        self.requires("etl/20.35.11")
+        self.requires("etl/20.35.14")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def layout(self):

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,7 +20,7 @@ endif(NOT DEFINED CMAKE_BUILD_TYPE)
 
 project(demos VERSION 0.0.1 LANGUAGES CXX)
 
-find_package(libhal-lpc40xx REQUIRED CONFIG)
+find_package(libhal-lpc40 REQUIRED CONFIG)
 find_package(libhal-esp8266 REQUIRED CONFIG)
 
 set(DEMOS wlan_client http_get)

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -16,12 +16,12 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, cmake_layout
 
 
-class RmdDemos(ConanFile):
+class esp8266_demos(ConanFile):
     settings = "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualBuildEnv"
 
     def requirements(self):
-        self.requires("libhal-lpc40xx/[^1.0.0]")
+        self.requires("libhal-lpc40/[^1.0.0]")
         self.requires("libhal-esp8266/1.0.2")
         self.tool_requires("gnu-arm-embedded-toolchain/11.3.0")
         self.tool_requires("cmake-arm-embedded/0.1.1")

--- a/demos/targets/lpc4074/initializer.cpp
+++ b/demos/targets/lpc4074/initializer.cpp
@@ -16,9 +16,9 @@
 #include <libhal-armcortex/startup.hpp>
 #include <libhal-armcortex/system_control.hpp>
 
-#include <libhal-lpc40xx/constants.hpp>
-#include <libhal-lpc40xx/system_controller.hpp>
-#include <libhal-lpc40xx/uart.hpp>
+#include <libhal-lpc40/constants.hpp>
+#include <libhal-lpc40/system_controller.hpp>
+#include <libhal-lpc40/uart.hpp>
 
 #include "../../hardware_map.hpp"
 

--- a/demos/targets/lpc4078/initializer.cpp
+++ b/demos/targets/lpc4078/initializer.cpp
@@ -16,9 +16,9 @@
 #include <libhal-armcortex/startup.hpp>
 #include <libhal-armcortex/system_control.hpp>
 
-#include <libhal-lpc40xx/constants.hpp>
-#include <libhal-lpc40xx/system_controller.hpp>
-#include <libhal-lpc40xx/uart.hpp>
+#include <libhal-lpc40/constants.hpp>
+#include <libhal-lpc40/system_controller.hpp>
+#include <libhal-lpc40/uart.hpp>
 
 #include "../../hardware_map.hpp"
 

--- a/tests/conanfile.py
+++ b/tests/conanfile.py
@@ -24,7 +24,6 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-        self.requires("etl/20.35.11")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def layout(self):


### PR DESCRIPTION
It seems that the old libhal-lpc40xx dependency was causing issues with the etl library's cmake generation. The cause of this is unknown, but libhal-lpc40xx is deprecated so can be migrated away from at this time.