### PR TITLE
⚡ Improve at::server_write() failure rate

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -25,7 +25,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_esp8266_conan(ConanFile):
     name = "libhal-esp8266"
-    version = "2.0.0-alpha.1"
+    version = "2.0.0-alpha.2"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libhal/libhal-esp8266"

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -24,7 +24,7 @@ class demos(ConanFile):
 
     def requirements(self):
         self.requires("libhal-lpc40/2.0.0-alpha.3")
-        self.requires("libhal-esp8266/2.0.0-alpha.1")
+        self.requires("libhal-esp8266/2.0.0-alpha.2")
         self.build_requires("cmake-arm-embedded/1.0.0")
 
     def layout(self):

--- a/include/libhal-esp8266/at.hpp
+++ b/include/libhal-esp8266/at.hpp
@@ -95,6 +95,7 @@ private:
       hal::serial& p_serial,
       std::span<hal::byte> p_buffer);
     void reset();
+    void set_state(std::uint8_t p_state);
 
   private:
     void update_state(hal::byte p_byte);


### PR DESCRIPTION
In some situations, during a server write, a packet will be returned
before a "SEND OK" response has been emitted. This is known and expected
behavior of the AT command system with ESP devices. The problem with
this behavior is that, the previous write function would toss out the
packet contents, reading until it reached the "SEND OK" message. This
will tend to cause the server_read() to read back nothing forever as the
previous packet has already been tossed out.

at::server_write() now searches for both the "SEND OK" response, as well
as the the start of a packet. If it finds either one, it returns a
successful function call. The packet manager has its state updated to
expect the section of a packet right after the start ensuring that
subsequent read operations get the packet stored in the internal working
buffer. This has helped to improve the number of read timeouts.

Bump version to 2.0.0-alpha.2