### PR TITLE
:bug: Fix segfault when using MinSizeRel

### DIFF
--- a/demos/applications/at.cpp
+++ b/demos/applications/at.cpp
@@ -29,8 +29,8 @@ hal::status application(hal::esp8266::hardware_map& p_map)
   auto& serial = *p_map.serial;
   auto& console = *p_map.console;
 
-  std::string_view ssid = "KAMMCE-PHONE";
-  std::string_view password = "roverteam";
+  std::string_view ssid = "ssid";
+  std::string_view password = "password";
 
   hal::print(console, "ESP8266 WiFi Client Application Starting...\n");
 

--- a/demos/hardware_map.hpp
+++ b/demos/hardware_map.hpp
@@ -31,4 +31,5 @@ struct hardware_map
 // Application function must be implemented by one of the compilation units
 // (.cpp) files.
 hal::status application(hal::esp8266::hardware_map& p_map);
-hal::result<hal::esp8266::hardware_map> initialize_target();
+hal::status initialize_processor();
+hal::result<hal::esp8266::hardware_map> initialize_platform();

--- a/demos/main.cpp
+++ b/demos/main.cpp
@@ -19,13 +19,19 @@
 
 int main()
 {
-  auto init_result = initialize_target();
+  auto processor_status = initialize_processor();
 
-  if (!init_result) {
+  if (!processor_status) {
     hal::halt();
   }
 
-  auto hardware_map = init_result.value();
+  auto platform_status = initialize_platform();
+
+  if (!platform_status) {
+    hal::halt();
+  }
+
+  auto hardware_map = platform_status.value();
   auto is_finished = application(hardware_map);
 
   if (!is_finished) {

--- a/demos/targets/lpc4074.cpp
+++ b/demos/targets/lpc4074.cpp
@@ -22,11 +22,16 @@
 
 #include "../hardware_map.hpp"
 
-hal::result<hal::esp8266::hardware_map> initialize_target()
+hal::status initialize_processor()
+{
+  hal::cortex_m::initialize_data_section();
+
+  return hal::success();
+}
+
+hal::result<hal::esp8266::hardware_map> initialize_platform()
 {
   using namespace hal::literals;
-
-  hal::cortex_m::initialize_data_section();
 
   // Set the MCU to the maximum clock speed
   HAL_CHECK(hal::lpc40::clock::maximum(10.0_MHz));

--- a/demos/targets/lpc4078.cpp
+++ b/demos/targets/lpc4078.cpp
@@ -22,12 +22,17 @@
 
 #include "../hardware_map.hpp"
 
-hal::result<hal::esp8266::hardware_map> initialize_target()
+hal::status initialize_processor()
 {
-  using namespace hal::literals;
-
   hal::cortex_m::initialize_data_section();
   hal::cortex_m::initialize_floating_point_unit();
+
+  return hal::success();
+}
+
+hal::result<hal::esp8266::hardware_map> initialize_platform()
+{
+  using namespace hal::literals;
 
   // Set the MCU to the maximum clock speed
   HAL_CHECK(hal::lpc40::clock::maximum(10.0_MHz));

--- a/demos/targets/stm32f103.cpp
+++ b/demos/targets/stm32f103.cpp
@@ -14,7 +14,7 @@
 
 #include "../hardware_map.hpp"
 
-hal::result<hal::esp8266::hardware_map> initialize_target()
+hal::result<hal::esp8266::hardware_map> initialize_platform()
 {
   using namespace hal::literals;
   return hal::new_error();


### PR DESCRIPTION
MinSizeRel will use fpu registers in initialize_platform which causes a segfault because the FPU has yet to be initialized. By using a new smaller function with just calls to init data section and FPU, the FPU registers are not used. This solution seems to work for now.

Rename initialize_target to initialize_platform.

Make at_benchmark readable and understandable via the console.