### PR TITLE
:recycle: Migrate to libhal-cmake-util

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -69,12 +69,14 @@ class libhal_esp8266_conan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler ({compiler}-{version}) does not support")
 
+    def build_requirements(self):
+        self.tool_requires("libhal-cmake-util/0.0.1")
+        self.test_requires("libhal-mock/[^2.0.0]")
+        self.test_requires("boost-ext-ut/1.1.9")
+
     def requirements(self):
         self.requires("libhal/[^2.0.0]")
         self.build_requires("libhal-util/[^2.1.0]")
-        self.build_requires("cmake-arm-embedded/1.0.0")
-        self.test_requires("libhal-mock/[^2.0.0]")
-        self.test_requires("boost-ext-ut/1.1.9")
 
     def layout(self):
         cmake_layout(self)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -19,7 +19,7 @@ project(demos VERSION 0.0.1 LANGUAGES CXX)
 find_package(libhal-lpc40 REQUIRED CONFIG)
 find_package(libhal-esp8266 REQUIRED CONFIG)
 
-set(platform_library $ENV{LIBHAL_PROCESSOR_LIBRARY})
+set(platform_library $ENV{LIBHAL_PLATFORM_LIBRARY})
 set(platform $ENV{LIBHAL_PLATFORM})
 
 set(DEMOS at at_benchmark)
@@ -31,10 +31,10 @@ foreach(demo IN LISTS DEMOS)
         main.cpp
         targets/${platform}.cpp
         applications/${demo}.cpp)
-    target_compile_options(${current_project} PRIVATE -g -Wall -Wextra)
+    target_compile_options(${current_project} PRIVATE -Wall -Wextra)
     target_compile_features(${current_project} PRIVATE cxx_std_20)
     target_link_libraries(${current_project} PRIVATE
         libhal::${platform_library}
         libhal::esp8266)
-    arm_post_build(${current_project})
+    libhal_post_build(${current_project})
 endforeach()

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -22,10 +22,12 @@ class demos(ConanFile):
     options = {"platform": ["ANY"]}
     default_options = {"platform": "unspecified"}
 
+    def build_requirements(self):
+        self.tool_requires("libhal-cmake-util/1.0.0")
+
     def requirements(self):
         self.requires("libhal-lpc40/2.0.0-alpha.3")
         self.requires("libhal-esp8266/2.0.0-alpha.3")
-        self.build_requires("cmake-arm-embedded/1.0.0")
 
     def layout(self):
         platform_directory = "build/" + str(self.options.platform)


### PR DESCRIPTION
libhal-cmake-util is a generic form of cmake-arm-embedded with improvements.