### PR TITLE
:construction_worker: Use ci/4.x.y version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ on:
   workflow_dispatch:
   pull_request:
   release:
-    types: [published]
+    types:
+      - published
+      - deleted
   push:
     branches:
       - main
@@ -27,16 +29,16 @@ on:
 
 jobs:
   ci:
-    uses: libhal/ci/.github/workflows/library.yml@4.1.0
+    uses: libhal/ci/.github/workflows/library.yml@4.x.y
     with:
       library: libhal-esp8266
       coverage: true
     secrets: inherit
   deploy:
-    uses: libhal/ci/.github/workflows/deploy.yml@4.1.0
+    uses: libhal/ci/.github/workflows/deploy.yml@4.x.y
     secrets: inherit
   build_lpc4078:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@4.1.0
+    uses: libhal/ci/.github/workflows/demo_builder.yml@4.x.y
     with:
       profile: lpc4078
       processor_profile: https://github.com/libhal/libhal-armcortex.git

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,6 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, cmake_layout
 from conan.tools.files import copy
 from conan.tools.build import check_min_cppstd
-from conan.errors import ConanInvalidConfiguration
 import os
 
 
@@ -25,7 +24,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_esp8266_conan(ConanFile):
     name = "libhal-esp8266"
-    version = "2.0.0"
+    version = "2.0.1"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libhal/libhal-esp8266"
@@ -56,28 +55,14 @@ class libhal_esp8266_conan(ConanFile):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)
 
-        def lazy_lt_semver(v1, v2):
-            lv1 = [int(v) for v in v1.split(".")]
-            lv2 = [int(v) for v in v2.split(".")]
-            min_length = min(len(lv1), len(lv2))
-            return lv1[:min_length] < lv2[:min_length]
-
-        compiler = str(self.settings.compiler)
-        version = str(self.settings.compiler.version)
-        minimum_version = self._compilers_minimum_version.get(compiler, False)
-
-        if minimum_version and lazy_lt_semver(version, minimum_version):
-            raise ConanInvalidConfiguration(
-                f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler ({compiler}-{version}) does not support")
-
     def build_requirements(self):
         self.tool_requires("libhal-cmake-util/0.0.1")
-        self.test_requires("libhal-mock/[^2.0.0]")
+        self.test_requires("libhal-mock/[^2.0.1]")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def requirements(self):
         self.requires("libhal/[^2.0.0]")
-        self.requires("libhal-util/[^2.0.0]")
+        self.requires("libhal-util/[^3.0.0]")
 
     def layout(self):
         cmake_layout(self)

--- a/demos/applications/at_benchmark.cpp
+++ b/demos/applications/at_benchmark.cpp
@@ -110,10 +110,10 @@ enum class connection_state
 
 struct http_header_parser_t
 {
-  hal::stream::find find_header_start;
-  hal::stream::find find_content_length;
-  hal::stream::parse<std::uint32_t> parse_content_length;
-  hal::stream::find find_end_of_header;
+  hal::stream_find find_header_start;
+  hal::stream_find find_content_length;
+  hal::stream_parse<std::uint32_t> parse_content_length;
+  hal::stream_find find_end_of_header;
 };
 
 http_header_parser_t new_http_header_parser()
@@ -121,11 +121,11 @@ http_header_parser_t new_http_header_parser()
   using namespace std::literals;
 
   return http_header_parser_t{
-    .find_header_start = hal::stream::find(hal::as_bytes("HTTP/1.1 "sv)),
+    .find_header_start = hal::stream_find(hal::as_bytes("HTTP/1.1 "sv)),
     .find_content_length =
-      hal::stream::find(hal::as_bytes("Content-Length: "sv)),
-    .parse_content_length = hal::stream::parse<std::uint32_t>(),
-    .find_end_of_header = hal::stream::find(hal::as_bytes("\r\n\r\n"sv)),
+      hal::stream_find(hal::as_bytes("Content-Length: "sv)),
+    .parse_content_length = hal::stream_parse<std::uint32_t>(),
+    .find_end_of_header = hal::stream_find(hal::as_bytes("\r\n\r\n"sv)),
   };
 }
 }  // namespace
@@ -175,7 +175,7 @@ hal::status application(hal::esp8266::hardware_map& p_map)
 
   auto http_header_parser = new_http_header_parser();
   // Skip of 0 means it starts in the finished state.
-  auto skip_payload = hal::stream::skip(0);
+  auto skip_payload = hal::stream_skip(0);
   bool header_finished = false;
   bool read_complete = true;
   bool write_error = false;
@@ -247,7 +247,7 @@ hal::status application(hal::esp8266::hardware_map& p_map)
     if (!header_finished &&
         hal::finished(http_header_parser.find_end_of_header)) {
       auto content_length = http_header_parser.parse_content_length.value();
-      skip_payload = hal::stream::skip(content_length);
+      skip_payload = hal::stream_skip(content_length);
       header_finished = true;
     }
 
@@ -257,7 +257,7 @@ hal::status application(hal::esp8266::hardware_map& p_map)
         read_complete = true;
 
         http_header_parser = new_http_header_parser();
-        skip_payload = hal::stream::skip(0);
+        skip_payload = hal::stream_skip(0);
 
         hal::print(console, ".");
       }

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -27,8 +27,8 @@ class demos(ConanFile):
 
     def requirements(self):
         if str(self.options.platform).startswith("lpc40"):
-            self.requires("libhal-lpc40/[^2.0.0]")
-        self.requires("libhal-esp8266/2.0.0-alpha.3")
+            self.requires("libhal-lpc40/[^2.1.1]")
+        self.requires("libhal-esp8266/2.0.1")
 
     def layout(self):
         platform_directory = "build/" + str(self.options.platform)

--- a/src/at.cpp
+++ b/src/at.cpp
@@ -246,8 +246,8 @@ hal::result<bool> at::is_connected_to_ap(deadline p_timeout)
   // Query the device to determine if it is still connected
   HAL_CHECK(write(*m_serial, "AT+CWJAP?\r\n"));
 
-  auto find_confirm = hal::stream::find(hal::as_bytes(ap_connected));
-  auto find_ok = hal::stream::find(hal::as_bytes(ok_response));
+  auto find_confirm = hal::stream_find(hal::as_bytes(ap_connected));
+  auto find_ok = hal::stream_find(hal::as_bytes(ok_response));
 
   while (hal::in_progress(find_confirm) && hal::in_progress(find_ok)) {
     std::array<hal::byte, 1> buffer;
@@ -330,8 +330,8 @@ hal::result<at::write_t> at::server_write(std::span<const hal::byte> p_data,
   HAL_CHECK(try_until(skip_past(*m_serial, hal::as_bytes(">"sv)), p_timeout));
   HAL_CHECK(hal::write(*m_serial, p_data));
 
-  auto find_packet = hal::stream::find(hal::as_bytes(start_of_packet));
-  auto find_send_finish = hal::stream::find(hal::as_bytes(send_finished));
+  auto find_packet = hal::stream_find(hal::as_bytes(start_of_packet));
+  auto find_send_finish = hal::stream_find(hal::as_bytes(send_finished));
 
   while (hal::in_progress(find_packet) && hal::in_progress(find_send_finish)) {
     std::array<hal::byte, 1> buffer;
@@ -362,9 +362,9 @@ hal::result<bool> at::is_connected_to_server(deadline p_timeout)
   // Query the device to determine if it is still connected
   HAL_CHECK(write(*m_serial, "AT+CIPSTATUS\r\n"));
 
-  auto find_status = hal::stream::find(hal::as_bytes(response_status));
-  auto find_start = hal::stream::find(hal::as_bytes(response_start));
-  auto find_ok = hal::stream::find(hal::as_bytes(ok_response));
+  auto find_status = hal::stream_find(hal::as_bytes(response_status));
+  auto find_start = hal::stream_find(hal::as_bytes(response_start));
+  auto find_ok = hal::stream_find(hal::as_bytes(ok_response));
 
   while (hal::in_progress(find_start) && hal::in_progress(find_ok)) {
     std::array<hal::byte, 1> buffer;

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -24,7 +24,6 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-        self.requires("libhal-util/2.0.0")
 
     def layout(self):
         cmake_layout(self)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,11 @@ find_package(libhal REQUIRED CONFIG)
 find_package(libhal-util REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME}
+
+  # Source
+  ../src/at.cpp
+
+  # Tests
   at.test.cpp
   main.test.cpp)
 


### PR DESCRIPTION
The 4.x.y branch scheme means that this repo will get the latest changes to the ci that does not include breaking changes.

:arrow_up: Upgrade to libhal-util/3.0.0